### PR TITLE
Fix endianness of implementations of DataConvertible

### DIFF
--- a/Sources/DataConvertible.swift
+++ b/Sources/DataConvertible.swift
@@ -16,19 +16,6 @@ public protocol DataConvertible {
     var data: Data { get }
 }
 
-public extension DataConvertible {
-    
-    init?(data: Data) {
-        guard data.count == MemoryLayout<Self>.size else { return nil }
-        self = data.withUnsafeBytes { $0.pointee }
-    }
-    
-    var data: Data {
-        var value = self
-        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
-    }
-}
-
 extension Data: DataConvertible {
     
     public init?(data: Data) {
@@ -53,18 +40,206 @@ extension String: DataConvertible {
     
 }
 
-extension Bool: DataConvertible {}
-extension Int: DataConvertible {}
-extension Int8: DataConvertible {}
-extension Int16: DataConvertible {}
-extension Int32: DataConvertible {}
-extension Int64: DataConvertible {}
-extension UInt: DataConvertible {}
-extension UInt8: DataConvertible {}
-extension UInt16: DataConvertible {}
-extension UInt32: DataConvertible {}
-extension UInt64: DataConvertible {}
-extension Float: DataConvertible {}
-extension Double: DataConvertible {}
-extension Date: DataConvertible {}
-extension URL: DataConvertible {}
+extension Bool: DataConvertible {
+    
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt8>.size else { return nil }
+        self = data.withUnsafeBytes { $0.pointee } != 0
+    }
+
+    public var data: Data {
+        var value: UInt8 = self ? 1 : 0
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Int: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<Int>.size else { return nil }
+        let bigEndian: Int = data.withUnsafeBytes { $0.pointee }
+        self = Int(bigEndian: bigEndian)
+    }
+
+    public var data: Data {
+        var bigEndian = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &bigEndian, count: 1))
+    }
+}
+
+extension UInt: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt>.size else { return nil }
+        self = UInt(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Int8: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<Int8>.size else { return nil }
+        self = data.withUnsafeBytes { $0.pointee }
+    }
+
+    public var data: Data {
+        var value = self
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension UInt8: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt8>.size else { return nil }
+        self = data.withUnsafeBytes { $0.pointee }
+    }
+
+    public var data: Data {
+        var value = self
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Int16: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<Int16>.size else { return nil }
+        self = Int16(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension UInt16: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt16>.size else { return nil }
+        self = UInt16(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Int32: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<Int32>.size else { return nil }
+        self = Int32(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension UInt32: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt32>.size else { return nil }
+        self = UInt32(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Int64: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<Int64>.size else { return nil }
+        self = Int64(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension UInt64: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt64>.size else { return nil }
+        self = UInt64(bigEndian: data.withUnsafeBytes { $0.pointee })
+    }
+
+    public var data: Data {
+        var value = self.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+    }
+}
+
+extension Float: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt32>.size else { return nil }
+        let bigEndian: UInt32 = data.withUnsafeBytes { $0.pointee }
+        let bitPattern = UInt32(bigEndian: bigEndian)
+        self = Float(bitPattern: bitPattern)
+    }
+
+    public var data: Data {
+        let bitPattern: UInt32 = self.bitPattern
+        var bigEndian = bitPattern.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &bigEndian, count: 1))
+    }
+}
+
+extension Double: DataConvertible {
+
+    public init?(data: Data) {
+        guard data.count == MemoryLayout<UInt64>.size else { return nil }
+        let bigEndian: UInt64 = data.withUnsafeBytes { $0.pointee }
+        let bitPattern = UInt64(bigEndian: bigEndian)
+        self = Double(bitPattern: bitPattern)
+    }
+
+    public var data: Data {
+        let bitPattern: UInt64 = self.bitPattern
+        var bigEndian = bitPattern.bigEndian
+        return Data(buffer: UnsafeBufferPointer(start: &bigEndian, count: 1))
+    }
+}
+
+extension Date: DataConvertible {
+
+    public init?(data: Data) {
+        guard let timeInterval = TimeInterval(data: data) else {
+            return nil
+        }
+        self = Date(timeIntervalSinceReferenceDate: timeInterval)
+    }
+
+    public var data: Data {
+        return self.timeIntervalSinceReferenceDate.data
+    }
+}
+
+extension URL: DataConvertible {
+
+    public init?(data: Data) {
+        guard let url = URL(dataRepresentation: data, relativeTo: nil, isAbsolute: true) else {
+            return nil
+        }
+        self = url
+    }
+
+    public var data: Data {
+        return self.absoluteURL.dataRepresentation
+    }
+}


### PR DESCRIPTION
Attempts to fix the following issues:

- [Implementation of DataConvertible for Float/Double is incorrect](https://github.com/agisboye/SwiftLMDB/issues/12)
- [Implementation of DataConvertible for Date is incorrect](https://github.com/agisboye/SwiftLMDB/issues/11)
- [Implementation of DataConvertible for URL is incorrect](https://github.com/agisboye/SwiftLMDB/issues/10)
- [Implementation of DataConvertible for Bool is incorrect](https://github.com/agisboye/SwiftLMDB/issues/9)
- [Implementation of DataConvertible for Int/UInt/… is incorrect](https://github.com/agisboye/SwiftLMDB/issues/8)

Note that this PR will break compatibility with any database created with an older version of SwiftLMDB. But then again in its current form there would be breakage regardless of this, eventually.