### PR TITLE
Allow SwiftLMDB to work as a read-only data source of an application

### DIFF
--- a/Sources/Database.swift
+++ b/Sources/Database.swift
@@ -64,8 +64,9 @@ public class Database {
     internal init(environment: Environment, name: String?, flags: Flags = []) throws {
 
         self.environment = environment
+        let transactionFlags : Transaction.Flags = environment.flags.contains(.readOnly) ? [.readOnly] : []
         
-        try Transaction(environment: environment) { transaction -> Transaction.Action in
+        try Transaction(environment: environment, flags: transactionFlags) { transaction -> Transaction.Action in
 
             let openStatus = mdb_dbi_open(transaction.handle, name?.cString(using: .utf8), UInt32(flags.rawValue), &handle)
             guard openStatus == 0 else {

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -73,7 +73,8 @@ public class Environment {
         }
         
         // Open the environment.
-        let DEFAULT_FILE_MODE: mode_t = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH // 755
+        let DEFAULT_USER_ACCESS = flags.contains(.readOnly) ? (S_IRUSR | S_IXUSR) : S_IRWXU
+        let DEFAULT_FILE_MODE: mode_t = DEFAULT_USER_ACCESS | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH // 755
 
         // TODO: Let user specify file mode
         let envOpenStatus = mdb_env_open(handle, path.cString(using: .utf8), UInt32(flags.rawValue), DEFAULT_FILE_MODE)

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -31,6 +31,7 @@ public class Environment {
     }
     
     internal private(set) var handle: OpaquePointer?
+    internal private(set) var flags: Flags
     
     /// Initializes a new environment instance. An environment may contain 0 or more databases.
     /// - parameter path: The path to the folder in which the environment should be created. The folder must exist and be writeable.
@@ -41,6 +42,8 @@ public class Environment {
     /// - throws: an error if operation fails. See `LMDBError`.
     public init(path: String, flags: Flags = [], maxDBs: UInt32? = nil, maxReaders: UInt32? = nil, mapSize: size_t? = nil) throws {
 
+        self.flags = flags
+        
         // Prepare the environment.
         let envCreateStatus = mdb_env_create(&handle)
         


### PR DESCRIPTION
When I tried using a pre-built lookup database as an application resource I got LMDBError error 26 when trying to open the database, even though I had set the environment flags .readOnly and .noLock. Firstly I made the default user file permissions vary with the .readOnly flag. Then I exposed the environment flags so that when opening the database within a transaction I could set the transaction as .readOnly as well. I didn't look to see if there was other transaction code that could use a similar treatment.